### PR TITLE
Support for Agda 2.6.1 & stdlib 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The motivation and design decisions behind agdarsec are detailed in:
 
 To typecheck and compile this project you will need:
 
-* Agda version 2.6.0.1
-* Agda's standard library Version 1.2
+* Agda version 2.6.1
+* Agda's standard library Version 1.3
 
 ## Ports
 

--- a/examples/Base.agda
+++ b/examples/Base.agda
@@ -9,7 +9,7 @@ open import Data.String as String
 open import Data.List.Base as L hiding ([_] ; module List)
 open import Data.List.Categorical as List
 open import Data.List.Sized.Interface
-open import Data.List.Any as Any
+open import Data.List.Relation.Unary.Any as Any
 open import Data.Vec as Vec hiding ([_])
 open import Data.Bool
 open import Data.Maybe

--- a/examples/Parentheses.agda
+++ b/examples/Parentheses.agda
@@ -7,7 +7,7 @@ open import Data.List.Base as List
 import Data.List.Sized.Interface
 open import Data.Bool
 open import Relation.Nullary
-open import Relation.Binary
+open import Relation.Binary hiding (DecidableEquality)
 
 open import Agda.Builtin.Equality
 open import Function

--- a/examples/RegExp.agda
+++ b/examples/RegExp.agda
@@ -11,7 +11,7 @@ open import Data.Maybe
 open import Data.Product
 open import Function
 open import Relation.Nullary
-open import Relation.Binary
+open import Relation.Binary hiding (DecidableEquality)
 open import Relation.Binary.PropositionalEquality
 
 open import Base

--- a/examples/STLC.agda
+++ b/examples/STLC.agda
@@ -6,7 +6,7 @@ open import Data.Empty
 open import Data.Bool.Base
 open import Data.Nat.Properties using (≤-refl)
 open import Data.Char.Base
-open import Data.String as String
+open import Data.String as String hiding (parens)
 open import Data.List.Base as List
 open import Data.List.NonEmpty
 open import Data.Vec as Vec
@@ -19,7 +19,7 @@ open import Function
 open import Relation.Nullary
 open import Relation.Nullary.Decidable using (map′)
 open import Relation.Unary as U renaming (_⇒_ to _⟶_)
-open import Relation.Binary as B
+open import Relation.Binary as B hiding (DecidableEquality)
 open import Relation.Binary.PropositionalEquality
 
 open import Text.Parser.Types

--- a/src/Data/List/Sized/Interface.agda
+++ b/src/Data/List/Sized/Interface.agda
@@ -25,7 +25,7 @@ instance
   Sized.view     vec []       = lift tt
   Sized.view     vec (x ∷ xs) = x , xs
 
-open import Data.Product.N-ary
+open import Data.Vec.Recursive
 
 instance
 

--- a/src/Relation/Binary/PropositionalEquality/Decidable/Core.agda
+++ b/src/Relation/Binary/PropositionalEquality/Decidable/Core.agda
@@ -2,7 +2,7 @@
 
 module Relation.Binary.PropositionalEquality.Decidable.Core where
 
-open import Relation.Binary
+open import Relation.Binary hiding (DecidableEquality)
 open import Relation.Binary.PropositionalEquality.Core
 
 record DecidableEquality {a} (A : Set a) : Set a where

--- a/src/Text/Parser/Combinators.agda
+++ b/src/Text/Parser/Combinators.agda
@@ -14,10 +14,10 @@ open import Data.Bool.Base hiding (_<_; _≤_)
 open import Data.Nat.Properties
 open import Data.List.Base as List hiding ([_] ; any)
 open import Data.List.NonEmpty as NonEmpty using (List⁺ ; _∷⁺_ ; _∷_)
-import Data.List.Any as Any
+import Data.List.Relation.Unary.Any as Any
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable
-open import Relation.Binary hiding (_⇒_)
+open import Relation.Binary hiding (_⇒_; DecidableEquality)
 open import Relation.Binary.PropositionalEquality.Decidable.Core
 import Data.String as String
 open String using () renaming (String to Text)

--- a/src/Text/Parser/Combinators/Char.agda
+++ b/src/Text/Parser/Combinators/Char.agda
@@ -6,7 +6,7 @@ open import Data.Nat.Base
 open import Data.Sum
 open import Data.Bool.Base
 open import Data.Char
-open import Data.String as String
+open import Data.String as String hiding (parens)
 open import Data.List.Base as List hiding ([_])
 open import Data.List.NonEmpty as NonEmpty hiding ([_])
 open import Category.Monad

--- a/src/Text/Parser/Combinators/Numbers.agda
+++ b/src/Text/Parser/Combinators/Numbers.agda
@@ -14,7 +14,7 @@ open import Data.Product
 open import Function
 open import Category.Monad
 open import Relation.Nullary
-open import Relation.Binary
+open import Relation.Binary hiding (DecidableEquality)
 open import Relation.Binary.PropositionalEquality.Decidable
 
 open import Data.Subset

--- a/travis/install_agda.sh
+++ b/travis/install_agda.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=2.6.0.1
+VERSION=2.6.1
 CURRENT=$(agda -V | sed "s/Agda version \([^-]*\).*/\1/")
 
 if ! type "agda" > /dev/null || [ ! "$CURRENT" = "$VERSION" ]; then
@@ -13,6 +13,6 @@ rm -rf $HOME/.agda
 mkdir -p $HOME/.agda
 cp libraries $HOME/.agda/
 cd $HOME/.agda/
-wget https://github.com/agda/agda-stdlib/archive/v1.2.tar.gz
-tar -xvzf v1.2.tar.gz
+wget https://github.com/agda/agda-stdlib/archive/v1.3.tar.gz
+tar -xvzf v1.3.tar.gz
 cd -

--- a/travis/libraries
+++ b/travis/libraries
@@ -1,1 +1,1 @@
-$HOME/.agda/agda-stdlib-1.2/standard-library.agda-lib
+$HOME/.agda/agda-stdlib-1.3/standard-library.agda-lib


### PR DESCRIPTION
👋 @gallais 

This updates agdarsec to be compatible with Agda 2.6.1 & Agda stdlib 1.3. 

The biggest incompatibility I found was [`DecidableEquality` was added to the standard library](https://agda.github.io/agda-stdlib/Relation.Binary.Definitions.html#4575), but I couldn't get it to play nicely as an implicit argument or instance argument in its new form, which was mucking up the usability of the combinators. Perhaps there's a better way to bridge compatibility there, but I'm fairly new to Agda 🙂 

I fixed a couple deprecation warnings, too.

I ran `agda --ignore-interfaces -i. -iexamples -isrc --html index.agda` for testing (+loading the library modules in `agda-mode`)

(Thank you for taking a look! Sorry if these updates are unwelcome)