### PR TITLE
Fix ambiguous name error with stdlib v1.4

### DIFF
--- a/examples/RegExp.agda
+++ b/examples/RegExp.agda
@@ -2,17 +2,16 @@ module RegExp where
 
 open import Data.Nat.Base
 open import Data.Bool.Base
-open import Data.Char as C
-open import Data.Vec using (Vec)
-open import Data.List.Base     as List
-open import Data.List.NonEmpty as NonEmpty
+open import Data.Char as C using (Char)
+open import Data.List.Base     as List using (List; []; _∷_)
+open import Data.List.NonEmpty as NonEmpty using (List⁺; toList; _∷_)
 import Data.List.Sized.Interface
-open import Data.Maybe
-open import Data.Product
-open import Function
-open import Relation.Nullary
+open import Data.Maybe using (Maybe; nothing; just; maybe)
+open import Data.Product using (uncurry)
+open import Function.Base using (_∘_; _$_; const; id)
+open import Relation.Nullary using (yes; no)
 open import Relation.Binary hiding (DecidableEquality)
-open import Relation.Binary.PropositionalEquality
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
 
 open import Base
 
@@ -107,4 +106,3 @@ _ = `[ interval 'a' 'z' ∷ interval 'A' 'Z' ∷ interval '0' '9' ∷ singleton 
   ∙ (literal '.' ∙ literal  'a' ∙ literal  'g' ∙ literal 'd')
   ∙ ((literal 'a')
   ∥  (literal 'a' ∙ literal 'i')) !
-

--- a/travis/install_agda.sh
+++ b/travis/install_agda.sh
@@ -13,6 +13,6 @@ rm -rf $HOME/.agda
 mkdir -p $HOME/.agda
 cp libraries $HOME/.agda/
 cd $HOME/.agda/
-wget https://github.com/agda/agda-stdlib/archive/v1.3.tar.gz
-tar -xvzf v1.3.tar.gz
+wget https://github.com/agda/agda-stdlib/archive/v1.4-rc1.tar.gz
+tar -xvzf v1.4-rc1.tar.gz
 cd -

--- a/travis/libraries
+++ b/travis/libraries
@@ -1,1 +1,1 @@
-$HOME/.agda/agda-stdlib-1.3/standard-library.agda-lib
+$HOME/.agda/agda-stdlib-1.4-rc1/standard-library.agda-lib


### PR DESCRIPTION
I've made a start at writing explicit import lists, by adding explicit import lists to most of the standard library modules in Text.Parser.Combinators. I've also updated a usage of any to any?, since the former will be deprecated in v1.4.