### PR TITLE
[ update ] machinery to use the `uncons` primitive

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -54,7 +54,7 @@ env:
   AGDA: agda -Werror +RTS -M3.5G -H3.5G -A128M -RTS -i. -i src/
 
 jobs:
-  test-categories:
+  test-agdarsec:
     runs-on: ubuntu-latest
     steps:
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The motivation and design decisions behind agdarsec are detailed in:
 
 To typecheck and compile this project you will need:
 
-* Agda version 2.6.1.1
-* Agda's standard library (dev version)
+* Agda version 2.6.2
+* Agda's standard library (version 1.7)
 
 ## Ports
 

--- a/examples/JSONTest.agda
+++ b/examples/JSONTest.agda
@@ -1,0 +1,27 @@
+{-# OPTIONS --guardedness #-}
+
+module JSONTest where
+
+open import Level using (0ℓ)
+open import Data.List.Base using (_∷_; [])
+open import Data.JSON
+open import Text.Parser 0ℓ
+  using (runParserIO; P-monad; P-monad0; P-monad+
+        ; vec; decide-char
+        ; Subset-refl)
+open import Text.Parser.JSON using (value)
+
+open import Function.Base using (_$_)
+
+open import IO.Base
+open import IO.Finite
+
+open import System.Environment
+
+main : Main
+main = run $ do
+  (fp ∷ []) ← getArgs
+    where _ → putStrLn "Pass a single filepath"
+  txt  ← readFile fp
+  json ← runParserIO value txt
+  putStrLn "Success!"

--- a/examples/README.agda
+++ b/examples/README.agda
@@ -15,3 +15,6 @@ import SExp
 
 -- example of a large parser
 import Large
+
+-- example of a JSON parser
+import JSONTest

--- a/index.agda
+++ b/index.agda
@@ -19,6 +19,10 @@ import Text.Parser.Combinators
 import Text.Parser.Combinators.Numbers
 import Text.Parser.Combinators.Char
 
+-- And even a concrete instance in:
+
+import Text.Parser.JSON
+
 -- We have some ready-to-use monads for parsing in:
 
 import Text.Parser.Monad
@@ -27,7 +31,7 @@ import Text.Parser.Monad
 
 import Text.Lexer
 
--- We have some fully worked-out in:
+-- We have some fully worked-out examples in:
 
 import Expr
 import STLC

--- a/src/Data/JSON.agda
+++ b/src/Data/JSON.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Data.JSON where
+
+open import Data.Bool.Base using (Bool)
+open import Data.Float.Base using (Float)
+open import Data.List.Base using (List)
+open import Data.Product using (_×_)
+open import Data.String.Base using (String)
+
+-- I wish I could use a sized type here but unfortunately they're not
+-- considered safe anymore.
+data JSON : Set where
+  null   : JSON
+  bool   : Bool → JSON
+  number : Float → JSON
+  string : String → JSON
+  array  : List JSON → JSON
+  object : List (String × JSON) → JSON

--- a/src/Data/Text/Sized.agda
+++ b/src/Data/Text/Sized.agda
@@ -19,7 +19,7 @@ private
   variable l : Level
 
 record Text (n : ℕ) : Set where
-  constructor mkTest
+  constructor mkText
   field
     value  : String
     .proof : length value ≡ n
@@ -61,6 +61,6 @@ instance
 
   text : Sized {l} [ Char ] (λ n → [ Text n ])
   Sized.view text {zero}  t = _
-  Sized.view text {suc n} (Level.lift (mkTest val prf)) =
+  Sized.view text {suc n} (Level.lift (mkText val prf)) =
     let (mkSplit hd tl prf _) = split val prf in
-    lift (hd , mkTest tl prf)
+    lift (hd , mkText tl prf)

--- a/src/Data/Text/Sized.agda
+++ b/src/Data/Text/Sized.agda
@@ -1,48 +1,66 @@
 module Data.Text.Sized where
 
-open import Data.Empty
+open import Level using (Level)
+open import Level.Bounded using ([_]; lower; lift)
+open import Data.Empty.Irrelevant
 open import Data.Unit
 open import Data.Nat.Base
+import Data.Nat.Properties as ℕₚ
 open import Data.Char.Base
-open import Data.String.Base hiding (length)
-open import Data.List.Base hiding (uncons)
+open import Data.String.Base using (String; length; uncons)
+open import Data.String.Unsafe
 open import Data.Maybe.Base
-open import Data.Pair
 open import Data.Product
-open import Data.Text
 open import Data.List.Sized.Interface
-open import Relation.Binary.PropositionalEquality
-open import Function
+open import Function.Base using (_$_; _∘′_; case_of_)
+open import Relation.Binary.PropositionalEquality as Eq using (_≡_; refl)
 
-open ≡-Reasoning
+private
+  variable l : Level
 
 record Text (n : ℕ) : Set where
-  field  value  : String
-         .proof : length (toList value) ≡ n
+  constructor mkTest
+  field
+    value  : String
+    .proof : length value ≡ n
+open Text
 
-⊥-irrelim : ∀ {ℓ} {A : Set ℓ} → .⊥ → A
-⊥-irrelim ()
+record Split (n : ℕ) (str : String) : Set where
+  constructor mkSplit
+  field
+    head   : Char
+    tail   : String
+    .size  : length tail ≡ n
+    .proof : uncons str ≡ just (head , tail)
+
+length-uncons : ∀ str {mcs} → uncons str ≡ mcs →
+                length str ≡ maybe′ (suc ∘′ length ∘′ proj₂) zero mcs
+length-uncons str eq with uncons str | length-tail str
+length-uncons str refl | nothing | p = p
+length-uncons str refl | just _  | p = p
+
+split : ∀ str {n} → .(_ : length str ≡ suc n) → Split n str
+split str {n} lgth with uncons str in eq
+... | just (c , s) = mkSplit c s (prf lgth) eq where
+
+  .prf : length str ≡  suc n → length s ≡ n
+  prf lgth = ℕₚ.suc-injective $ begin
+    suc (length s) ≡˘⟨ length-uncons str eq ⟩
+    length str     ≡⟨ lgth ⟩
+    suc n          ∎ where open Eq.≡-Reasoning
+
+... | nothing      = ⊥-elim (case prf lgth of λ ()) where
+
+  .prf : length str ≡ suc n → 0 ≡ suc n
+  prf lgth = begin
+    0          ≡˘⟨ length-uncons str eq ⟩
+    length str ≡⟨ lgth ⟩
+    suc n      ∎ where open Eq.≡-Reasoning
 
 instance
 
-  text : Sized Char Text
-  Sized.view text {zero}  _  = _
-  Sized.view text {suc n} t with uncons (Text.value t) | uncons-list (Text.value t)
-  ... | just (c , s)  | eq = c , record { value = s
-                                        ; proof = pr } where
-
-    .pr : length (toList s) ≡ n
-    pr = cong pred $ begin
-          length (c ∷ toList s)           ≡⟨ cong length (sym eq) ⟩
-          length (toList (Text.value t))  ≡⟨ Text.proof t ⟩
-          suc n
-         ∎
-
-  ... | nothing       | eq = ⊥-irrelim (case pr of λ ()) where
-
-    .pr : 0 ≡ suc n
-    pr = begin
-           0                               ≡⟨ cong length (sym eq) ⟩
-           length (toList (Text.value t))  ≡⟨ Text.proof t ⟩
-           suc n
-         ∎
+  text : Sized {l} [ Char ] (λ n → [ Text n ])
+  Sized.view text {zero}  t = _
+  Sized.view text {suc n} (Level.lift (mkTest val prf)) =
+    let (mkSplit hd tl prf _) = split val prf in
+    lift (hd , mkTest tl prf)

--- a/src/Text/Parser/Combinators/Char.agda
+++ b/src/Text/Parser/Combinators/Char.agda
@@ -4,22 +4,26 @@ open import Text.Parser.Types.Core using (Parameters)
 
 module Text.Parser.Combinators.Char {l} {P : Parameters l} where
 
-open import Data.Bool.Base using (T; not)
+open import Data.Bool.Base using (T; not; if_then_else_)
 open import Data.Char.Base using (Char)
 open import Data.List.Base as List using ([]; _∷_; null)
 open import Data.List.NonEmpty as List⁺ using (_∷_)
+open import Data.Maybe.Base using (nothing; maybe; fromMaybe)
 open import Data.Nat.Base using (ℕ)
+import Data.Nat.Show as ℕ
+open import Data.Product using (_,_)
 open import Data.String.Base as String using (String)
-open import Data.Sum.Base using ()
+open import Data.Vec.Base as Vec using (toList)
 
 open import Category.Monad using (RawMonadPlus)
-open import Function.Base using (_∘′_; _$′_)
+open import Function.Base using (_∘′_; _$′_; _$_)
 
+open import Relation.Nullary using (does)
 open import Relation.Unary
 open import Induction.Nat.Strong using (□_)
 open import Data.List.Sized.Interface using (Sized)
 open import Data.Subset using (Subset; into)
-open import Relation.Binary.PropositionalEquality.Decidable using (DecidableEquality)
+open import Relation.Binary.PropositionalEquality.Decidable using (DecidableEquality; decide)
 
 open import Level.Bounded
 open import Text.Parser.Types P
@@ -33,13 +37,19 @@ module _ {{𝕊 : Sized Tok Toks}}
          {{ℂ : Subset Char (theSet Tok)}}
          where
 
- module ℂ = Subset ℂ
+ private module ℂ = Subset ℂ
 
  char : Char → ∀[ Parser Tok ]
  char = exact ∘′ ℂ.into
 
  anyCharBut : Char → ∀[ Parser Tok ]
  anyCharBut = anyTokenBut ∘′ ℂ.into
+
+ noneOfChars : List.List Char → ∀[ Parser Tok ]
+ noneOfChars = noneOf ∘′ List.map ℂ.into
+
+ anyOfChars : List.List Char → ∀[ Parser Tok ]
+ anyOfChars = anyOf ∘′ List.map ℂ.into
 
  space : ∀[ Parser Tok ]
  space = anyOf $′ List.map ℂ.into $′ ' ' ∷ '\t' ∷ '\n' ∷ []
@@ -85,3 +95,82 @@ module _ {{𝕊 : Sized Tok Toks}}
 
  alphanum : ∀[ Parser (Tok ⊎ [ ℕ ]) ]
  alphanum = alpha <⊎> num
+
+module _ {{𝕊 : Sized Tok Toks}}
+         {{𝕄 : RawMonadPlus M}}
+         {{𝔻 : DecidableEquality (theSet Tok)}}
+         {{ℂ  : Subset Char (theSet Tok)}}
+         {{ℂ⁻ : Subset (theSet Tok)  Char}}
+         where
+
+ private
+   module ℂ = Subset ℂ
+   module ℂ⁻ = Subset ℂ⁻
+
+ stringLiteral : ∀[ Parser [ String ] ]
+ stringLiteral =
+   convert <$> (char '"'
+           &?> box escaped
+           <&> box (list⁺ (unescaped <&?> box escaped)
+           <?& char '"'))
+
+   where
+
+     toks : Set≤ _
+     toks = List⁺ Tok
+
+     unescaped : ∀[ Parser toks ]
+     unescaped = list⁺ (noneOfChars ('\\' ∷ '"' ∷ []))
+
+     convertUnicode : Vec.Vec ℕ 4 → theSet toks
+     convertUnicode ds = List⁺.map ℂ.into
+                       $ '\\' ∷ 'u' ∷ List.map toChar (toList ds)
+
+       where
+
+         toChar : ℕ → Char -- only for hexadecimal digits
+         toChar 0  = '0'
+         toChar 1  = '1'
+         toChar 2  = '2'
+         toChar 3  = '3'
+         toChar 4  = '4'
+         toChar 5  = '5'
+         toChar 6  = '6'
+         toChar 7  = '7'
+         toChar 8  = '8'
+         toChar 9  = '9'
+         toChar 10 = 'a'
+         toChar 11 = 'b'
+         toChar 12 = 'c'
+         toChar 13 = 'd'
+         toChar 14 = 'e'
+         toChar _  = 'f'
+
+     escaped : ∀[ Parser toks ]
+     escaped =
+       let unicode : ∀[ Parser toks ]
+           unicode = convertUnicode <$> replicate 4 hexadecimalDigit
+
+           chunks : ∀[ Parser (List⁺ toks) ]
+           chunks = list⁺ ((λ (a , mb) → fromMaybe (a ∷ []) mb)
+             <$> (char '\\' -- escaping
+             &> box ((_, nothing) <$> anyOfChars ('"' ∷ '\\' ∷ [])) -- special characters
+               <|> anyTok &?>>= λ c → box $
+                     if does (decide 𝔻 c (ℂ.into 'u')) -- better be a unicode character
+                     then unicode
+                     else fail))
+       in List⁺.concat <$> chunks
+
+     convert : theSet (Maybe toks × Maybe (List⁺ (toks × Maybe toks))) → String
+     convert (mt , mts) = let open List in
+       String.fromList $
+         fromMToks mt ++
+          maybe (concatMap (λ (ts , mts) → fromToks ts ++ fromMToks mts) ∘′ List⁺.toList) [] mts
+
+       where
+
+         fromToks : theSet toks → List.List Char
+         fromToks = List⁺.toList ∘′ List⁺.map ℂ⁻.into
+
+         fromMToks : theSet (Maybe toks) → List.List Char
+         fromMToks = maybe fromToks []

--- a/src/Text/Parser/Combinators/Char.agda
+++ b/src/Text/Parser/Combinators/Char.agda
@@ -4,11 +4,11 @@ open import Text.Parser.Types.Core using (Parameters)
 
 module Text.Parser.Combinators.Char {l} {P : Parameters l} where
 
-open import Data.Bool.Base using (T; not; if_then_else_)
+open import Data.Bool.Base using (T; not)
 open import Data.Char.Base using (Char)
 open import Data.List.Base as List using ([]; _∷_; null)
 open import Data.List.NonEmpty as List⁺ using (_∷_)
-open import Data.Maybe.Base using (nothing; maybe; fromMaybe)
+open import Data.Maybe.Base using (nothing; just; maybe; fromMaybe)
 open import Data.Nat.Base using (ℕ)
 import Data.Nat.Show as ℕ
 open import Data.Product using (_,_)
@@ -148,17 +148,14 @@ module _ {{𝕊 : Sized Tok Toks}}
 
      escaped : ∀[ Parser toks ]
      escaped =
-       let unicode : ∀[ Parser toks ]
-           unicode = convertUnicode <$> replicate 4 hexadecimalDigit
+       let unicode : ∀[ Parser (Maybe toks) ]
+           unicode = just ∘′ convertUnicode <$> replicate 4 hexadecimalDigit
 
            chunks : ∀[ Parser (List⁺ toks) ]
            chunks = list⁺ ((λ (a , mb) → fromMaybe (a ∷ []) mb)
              <$> (char '\\' -- escaping
-             &> box ((_, nothing) <$> anyOfChars ('"' ∷ '\\' ∷ [])) -- special characters
-               <|> anyTok &?>>= λ c → box $
-                     if does (decide 𝔻 c (ℂ.into 'u')) -- better be a unicode character
-                     then unicode
-                     else fail))
+             &> box ((_, nothing) <$> anyOfChars ('"' ∷ '\\' ∷ 'r' ∷ 'n' ∷ 't' ∷ [])) -- special characters
+               <|> char 'u' <&> box unicode))
        in List⁺.concat <$> chunks
 
      convert : theSet (Maybe toks × Maybe (List⁺ (toks × Maybe toks))) → String

--- a/src/Text/Parser/Combinators/Numbers.agda
+++ b/src/Text/Parser/Combinators/Numbers.agda
@@ -75,7 +75,7 @@ module _ {{𝕄 : RawMonadPlus M}}
 
    eNotation : ∀[ Parser [ Maybe Sign × ℕ ] ]
    eNotation = anyOf (ℂ.into 'E' ∷ ℂ.into 'e' ∷ [])
-             &> box sign <?&> decimalℕ
+             &> box (sign <?&> decimalℕ)
 
    fromENotation : Maybe Sign × ℕ → Float → Float
    fromENotation (ms , e) f = case fromMaybe Sign.+ ms of λ where

--- a/src/Text/Parser/Combinators/Numbers.agda
+++ b/src/Text/Parser/Combinators/Numbers.agda
@@ -5,17 +5,19 @@ open import Text.Parser.Types.Core using (Parameters)
 module Text.Parser.Combinators.Numbers {l} {P : Parameters l} where
 
 open import Data.Char.Base using (Char)
-open import Data.Integer.Base using (ℤ; -_; +_)
+open import Data.Float.Base as Float using (Float; fromℕ; fromℤ)
+open import Data.Integer.Base using (ℤ; -_; +_; _◃_)
 open import Data.List.Base as List using ([]; _∷_)
-open import Data.List.NonEmpty as List⁺ using ()
-open import Data.Nat.Base using (ℕ; _+_; _*_)
-open import Data.Product as Product using (_,_; uncurry)
-
+open import Data.List.NonEmpty as List⁺ using (List⁺)
 open import Data.List.Sized.Interface
+open import Data.Maybe.Base using (Maybe; fromMaybe; maybe′)
+open import Data.Nat.Base as ℕ using (ℕ; _+_; _*_)
+import Data.Nat.GeneralisedArithmetic
+open import Data.Product as Product using (_×_; _,_; uncurry)
+open import Data.Sign.Base using (Sign)
 open import Data.Sum.Base using ([_,_]′)
-open import Data.Maybe.Base using (maybe′)
 
-open import Function.Base using (const; id; _$_; _∘′_)
+open import Function.Base using (const; id; _$_; _∘′_; case_of_)
 open import Category.Monad using (RawMonadPlus)
 
 open import Relation.Unary
@@ -45,11 +47,46 @@ module _ {{𝕄 : RawMonadPlus M}}
        $ (10 , 'a') ∷ (11 , 'b') ∷ (12 , 'c')
        ∷ (13 , 'd') ∷ (14 , 'e') ∷ (15 , 'f') ∷ []
 
+ private
+   natFromDigits : List⁺ ℕ → ℕ
+   natFromDigits = List⁺.foldl (λ ih v → ih * 10 + v) id
+
+ sign : ∀[ Parser [ Sign ] ]
+ sign = Sign.- <$ anyOf (List.map ℂ.into $ '-' ∷ '−' ∷ [])
+    <|> Sign.+ <$ exact (ℂ.into '+')
+
  decimalℕ : ∀[ Parser [ ℕ ] ]
- decimalℕ = convert <$> list⁺ decimalDigit where
-  convert = List⁺.foldl (λ ih v → ih * 10 + v) id
+ decimalℕ = natFromDigits  <$> list⁺ decimalDigit
 
  decimalℤ : ∀[ Parser [ ℤ ] ]
  decimalℤ = uncurry convert <$> (sign <?&> decimalℕ) where
-   sign    = anyOf (List.map ℂ.into $ '-' ∷ '−' ∷ []) <⊎> exact (ℂ.into '+')
-   convert = λ s → maybe′ [ const (-_) , const id ]′ id s ∘′ +_
+   convert : Maybe Sign → ℕ → ℤ
+   convert ms n = fromMaybe Sign.+ ms ◃ n
+
+ decimalFloat : ∀[ Parser [ Float ] ]
+ decimalFloat = convert <$> rawDouble where
+
+   fractional : ∀[ Parser [ List⁺ ℕ ] ]
+   fractional = exact (ℂ.into '.') &> box (list⁺ decimalDigit)
+
+   fromFractional : List⁺ ℕ → Float
+   fromFractional ds = fromℕ (natFromDigits ds)
+               Float.÷ fromℕ (10 ℕ.^ List⁺.length ds)
+
+   eNotation : ∀[ Parser [ Maybe Sign × ℕ ] ]
+   eNotation = anyOf (ℂ.into 'E' ∷ ℂ.into 'e' ∷ [])
+             &> box sign <?&> decimalℕ
+
+   fromENotation : Maybe Sign × ℕ → Float → Float
+   fromENotation (ms , e) f = case fromMaybe Sign.+ ms of λ where
+     Sign.- → f Float.÷ fromℕ (10 ℕ.^ e)
+     Sign.+ → f Float.* fromℕ (10 ℕ.^ e)
+
+   rawDouble : ∀[ Parser [ (ℤ × Maybe (List⁺ ℕ)) × Maybe (Maybe Sign × ℕ) ] ]
+   rawDouble = (decimalℤ <&?> box fractional) <&?> box eNotation
+
+   convert : (ℤ × Maybe (List⁺ ℕ)) × Maybe (Maybe Sign × ℕ) → Float
+   convert ((int , mfrac) , menot)
+     = maybe′ fromENotation id menot
+     $ maybe′ (λ m f → f Float.+ fromFractional m) id mfrac
+     $ fromℤ int

--- a/src/Text/Parser/JSON.agda
+++ b/src/Text/Parser/JSON.agda
@@ -1,0 +1,116 @@
+-- Parser based on RFC 8259: https://tools.ietf.org/html/rfc8259
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Text.Parser.Types.Core using (Parameters)
+
+module Text.Parser.JSON {l} {P : Parameters l} where
+
+open import Category.Monad using (RawMonadPlus)
+
+open import Data.Bool.Base using (Bool; true; false)
+open import Data.Char.Base using (Char)
+open import Data.Float.Base using (Float)
+open import Data.List.Base using (List; []; _∷_)
+import Data.List.NonEmpty as List⁺
+open import Data.List.Sized.Interface
+open import Data.Maybe.Base using (maybe′)
+open import Data.Product using (_×_; uncurry)
+open import Data.String.Base using (String)
+open import Data.Subset using (Subset; into)
+open import Data.Unit.Base using (⊤)
+
+open import Induction.Nat.Strong as Box using (□_; fix)
+
+open import Function.Base using (_$_; _∘′_)
+
+open import Relation.Unary
+open import Relation.Binary.PropositionalEquality.Decidable using (DecidableEquality)
+
+open import Level.Bounded using (theSet; [_])
+open import Text.Parser.Types P
+open import Text.Parser.Combinators {P = P}
+open import Text.Parser.Combinators.Char {P = P}
+open import Text.Parser.Combinators.Numbers {P = P}
+open Parameters P
+
+
+module JSON where
+
+  -- I wish I could use a sized type here but unfortunately they're not
+  -- considered safe anymore.
+  data JSON : Set where
+    null   : JSON
+    bool   : Bool → JSON
+    number : Float → JSON
+    string : String → JSON
+    array  : List JSON → JSON
+    object : List (String × JSON) → JSON
+
+open JSON using (JSON)
+
+module _ {{𝕄 : RawMonadPlus M}}
+         {{𝕊 : Sized Tok Toks}}
+         {{𝔻 : DecidableEquality (theSet Tok)}}
+         {{ℂ : Subset Char (theSet Tok)}}
+         {{ℂ⁻ : Subset (theSet Tok) Char}}
+         where
+
+
+-- We assume that when we call a subparser all of the whitespace before
+-- the potential token has been consumed already. So we should systematically
+-- consume spaces after the tokens we have happily recognised.
+
+-- Structural characters
+
+  structuralChar : Char → ∀[ Parser [ ⊤ ] ]
+  structuralChar c = _ <$ (char c <&? box spaces)
+
+  beginArray     = structuralChar '['
+  beginObject    = structuralChar '{'
+  endArray       = structuralChar ']'
+  endObject      = structuralChar '}'
+  nameSeparator  = structuralChar ':'
+  valueSeparator = structuralChar ','
+
+-- Subparser for members, provided a subparser for smaller JSON objects
+-- According to the RFC:
+-- member = string name-separator value
+
+  member : ∀[ □ Parser [ JSON ] ⇒ Parser [ String × JSON ] ]
+  member rec = stringLiteral <&? box spaces
+             <&> box (nameSeparator &> rec)
+
+-- Subparser for JSON objects, provided a subparser for smaller JSON objects
+-- According to the RFC:
+-- object = begin-object [ member *( value-separator member ) ] end-object
+
+  object : ∀[ □ Parser [ JSON ] ⇒ Parser [ List (String × JSON) ] ]
+  object rec =
+    maybe′ (uncurry λ a mas → a ∷ maybe′ List⁺.toList [] mas) []
+    <$> (beginObject
+         &?> box (member rec <&?> box (list⁺ (valueSeparator &> box (member rec))))
+         <& box endObject)
+
+-- Subparser for JSON arrays, provided a subparser for smaller JSON objects
+-- According to the RFC:
+-- array = begin-array [ value *( value-separator value ) ] end-array
+
+  array : ∀[ □ Parser [ JSON ] ⇒ Parser [ List JSON ] ]
+  array rec =
+    maybe′ (uncurry λ a mas → a ∷ maybe′ List⁺.toList [] mas) []
+    <$> (beginArray
+         &?> lift2l (λ p q → p <&?> box q) rec (list⁺ (valueSeparator &> rec))
+         <& box endArray)
+
+-- Parsing JSON values
+  value : ∀[ Parser [ JSON ] ]
+  value = (spaces ?&>_) $ fix (Parser [ JSON ]) $ λ rec →
+    alts $ (JSON.null       <$  text "null"   <&? box spaces)
+         ∷ (JSON.bool true  <$  text "true"   <&? box spaces)
+         ∷ (JSON.bool false <$  text "false"  <&? box spaces)
+         ∷ (JSON.number     <$> decimalFloat  <&? box spaces)
+         ∷ (JSON.string     <$> stringLiteral <&? box spaces)
+         ∷ (JSON.array      <$> array rec)
+         ∷ (JSON.object     <$> object rec)
+         ∷ []

--- a/src/Text/Parser/JSON.agda
+++ b/src/Text/Parser/JSON.agda
@@ -34,20 +34,7 @@ open import Text.Parser.Combinators.Char {P = P}
 open import Text.Parser.Combinators.Numbers {P = P}
 open Parameters P
 
-
-module JSON where
-
-  -- I wish I could use a sized type here but unfortunately they're not
-  -- considered safe anymore.
-  data JSON : Set where
-    null   : JSON
-    bool   : Bool → JSON
-    number : Float → JSON
-    string : String → JSON
-    array  : List JSON → JSON
-    object : List (String × JSON) → JSON
-
-open JSON using (JSON)
+open import Data.JSON as JSON using (JSON)
 
 module _ {{𝕄 : RawMonadPlus M}}
          {{𝕊 : Sized Tok Toks}}
@@ -64,7 +51,7 @@ module _ {{𝕄 : RawMonadPlus M}}
 -- Structural characters
 
   structuralChar : Char → ∀[ Parser [ ⊤ ] ]
-  structuralChar c = _ <$ (char c <&? box spaces)
+  structuralChar c = _ <$ (char c  <&? box spaces)
 
   beginArray     = structuralChar '['
   beginObject    = structuralChar '{'

--- a/src/Text/Parser/Monad.agda
+++ b/src/Text/Parser/Monad.agda
@@ -7,6 +7,8 @@ open import Data.Char.Base using (Char)
 open import Data.List.Base as List using ([]; _∷_; drop)
 open import Data.Maybe.Base as Maybe using (nothing; just; maybe′)
 open import Data.Product using (_,_; proj₁; proj₂; map₁; map₂)
+open import Data.String.Base using (String)
+open import Data.Text.Sized using (Text)
 
 open import Data.Subset using (Subset; into)
 open import Function.Base using (_∘′_; _$′_)
@@ -119,6 +121,9 @@ module AgdarsecT
   chars : Parameters l
   chars = param [ Char ] (Vec [ Char ]) recordChar
 
+  text : Parameters l
+  text = param [ Char ] (λ n → [ Text n ]) recordChar
+
 module Agdarsec l (E Ann : Set≤ l) (𝕊 : Subset (theSet ([ Position ] × List Ann)) (theSet E)) where
 
   private module M = AgdarsecT E Ann Id.monad 𝕊
@@ -138,6 +143,14 @@ module Agdarsec′ {l : Level} where
   vec Tok = record
     { Tok         = Tok
     ; Toks        = Vec Tok
+    ; M           = Agdarsec ⊤ ⊥
+    ; recordToken = λ _ → M.pure _
+    } where module M = RawMonad monad
+
+  txt : Set≤ l → Parameters l
+  txt Tok = record
+    { Tok         = Tok
+    ; Toks        = λ n → [ Text n ]
     ; M           = Agdarsec ⊤ ⊥
     ; recordToken = λ _ → M.pure _
     } where module M = RawMonad monad

--- a/src/Text/Parser/Monad.agda
+++ b/src/Text/Parser/Monad.agda
@@ -121,8 +121,8 @@ module AgdarsecT
   chars : Parameters l
   chars = param [ Char ] (Vec [ Char ]) recordChar
 
-  text : Parameters l
-  text = param [ Char ] (λ n → [ Text n ]) recordChar
+  raw : Parameters l
+  raw = param [ Char ] (λ n → [ Text n ]) recordChar
 
 module Agdarsec l (E Ann : Set≤ l) (𝕊 : Subset (theSet ([ Position ] × List Ann)) (theSet E)) where
 


### PR DESCRIPTION
Now that we have 2.6.2 we can use the `uncons` primitive to avoid
converting the whole string to a vector of characters.

* [x] benchmark vec vs. txt