### PR TITLE
[ new ] module specialised to 0ℓ

### DIFF
--- a/examples/Base.agda
+++ b/examples/Base.agda
@@ -31,6 +31,7 @@ open import Relation.Binary.PropositionalEquality.Decidable public
 open import Induction.Nat.Strong hiding (<-lower ; ≤-lower) public
 
 open import Data.Subset public
+open import Data.Singleton public
 
 open import Text.Parser.Types.Core                public
 open import Text.Parser.Types                     public
@@ -42,10 +43,6 @@ open import Text.Parser.Monad                     public
 open import Text.Parser.Monad.Result hiding (map) public
 
 open Agdarsec′ public
-
-infix 0 _!
-data Singleton {a} {A : Set a} : A → Set a where
-  _! : (a : A) → Singleton a
 
 record Tokenizer (A : Set≤ l) : Set (level (level≤ A)) where
   constructor mkTokenizer

--- a/examples/SExp.agda
+++ b/examples/SExp.agda
@@ -1,5 +1,3 @@
-{-# OPTIONS --guardedness #-}
-
 module SExp where
 
 open import Level using (0ℓ)

--- a/examples/SExp.agda
+++ b/examples/SExp.agda
@@ -19,17 +19,16 @@ open import Data.Product
 open import Data.Subset
 open import Function.Base
 open import Induction.Nat.Strong
-open import Relation.Unary using (IUniversal ; _⇒_)
 open import Relation.Binary.PropositionalEquality.Decidable
 
-open import Text.Parser 0ℓ
+open import Text.Parser
 
 module _ where
 
-  sexp : ∀[ Parser [ SExp ] ]
+  sexp : ∀[ Parser SExp ]
   sexp =
     -- SExp is an inductive type so we build the parser as a fixpoint
-    fix (Parser [ SExp ]) $ λ rec →
+    fix (Parser SExp) $ λ rec →
         -- First we have atoms. Assuming we have already consumed the leading space, an
         -- atom is just a non empty list of alphabetical characters.
 
@@ -49,7 +48,7 @@ module _ where
         -- I give a bit more details about `lift` and `box` below.
         -- As for the previous case we use `<$>` to massage the result into a `SExp`.
         sexp = (λ (a , mb) → maybe (Pair a) a mb)
-               <$> parens (lift2 (λ p q → (spaces ?&> p <&? box spaces) <&?> box (q <&? box spaces))
+               <$> parens (lift2 (λ p q → withSpaces p <&?> box (q <&? box spaces))
                                  rec
                                  rec)
      in
@@ -71,10 +70,8 @@ module _ where
 
 
   -- The full parser is obtained by disregarding spaces before & after the expression
-  SEXP : ∀[ Parser [ SExp ] ]
+  SEXP : ∀[ Parser SExp ]
   SEXP = spaces ?&> sexp <&? box spaces
-
-open import Base Level.zero
 
 -- And we can run the thing on a test (which is very convenient when refactoring grammars!..):
 _ : "((  this    is)

--- a/src/Data/Singleton.agda
+++ b/src/Data/Singleton.agda
@@ -2,7 +2,7 @@
 
 module Data.Singleton where
 
-open import Level using (Level)
+open import Level using (Level; levelOfType)
 open import Data.Empty.Polymorphic using (⊥)
 open import Data.Maybe.Base using (Maybe; nothing; just)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
@@ -17,14 +17,14 @@ infix 0 _!
 data Singleton {A : Set a} : A → Set a where
   _! : (a : A) → Singleton a
 
-fromJust : Maybe {a} A → Set a
+fromJust : Maybe A → Set (levelOfType A)
 fromJust (just a) = Singleton a
 fromJust nothing  = ⊥
 
-fromInj₁ : {A : Set a} → A ⊎ B → Set a
+fromInj₁ : A ⊎ B → Set (levelOfType A)
 fromInj₁ (inj₁ a) = Singleton a
 fromInj₁ (inj₂ _) = ⊥
 
-fromInj₂ : {B : Set b} → A ⊎ B → Set b
+fromInj₂ : A ⊎ B → Set (levelOfType B)
 fromInj₂ (inj₁ _) = ⊥
 fromInj₂ (inj₂ b) = Singleton b

--- a/src/Data/Singleton.agda
+++ b/src/Data/Singleton.agda
@@ -1,0 +1,30 @@
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Singleton where
+
+open import Level using (Level)
+open import Data.Empty.Polymorphic using (⊥)
+open import Data.Maybe.Base using (Maybe; nothing; just)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+
+private
+  variable
+    a b : Level
+    A : Set a
+    B : Set b
+
+infix 0 _!
+data Singleton {A : Set a} : A → Set a where
+  _! : (a : A) → Singleton a
+
+fromJust : Maybe {a} A → Set a
+fromJust (just a) = Singleton a
+fromJust nothing  = ⊥
+
+fromInj₁ : {A : Set a} → A ⊎ B → Set a
+fromInj₁ (inj₁ a) = Singleton a
+fromInj₁ (inj₂ _) = ⊥
+
+fromInj₂ : {B : Set b} → A ⊎ B → Set b
+fromInj₂ (inj₁ _) = ⊥
+fromInj₂ (inj₂ b) = Singleton b

--- a/src/Text/Parser.agda
+++ b/src/Text/Parser.agda
@@ -1,86 +1,325 @@
+------------------------------------------------------------------------
+-- An opinionated frontend for the parser combinator library.
+-- This module re-exports specialised versions of the combinators.
+-- The design choices are as follows:
+--
+-- * Everything at level 0 (see Text.Parser.Polymorphic otherwise)
+-- * Char as the type of tokens
+-- * Sized text as the type of token lists
+-- * Position as the error annotation
+--
+------------------------------------------------------------------------
+
 {-# OPTIONS --guardedness #-}
 
-open import Level using (Level)
+module Text.Parser where
 
-module Text.Parser (l : Level) where
-
-open import Function.Identity.Categorical using (Identity)
-open import Category.Monad
+open import Level using (0ℓ)
+open import Level.Bounded as Level≤ using ([_])
+open import Category.Monad using (RawMonad; RawMonadZero; RawMonadPlus)
+open import Function.Base using (const; _∘′_; case_of_)
+open import Function.Identity.Categorical as Identity
+open import Data.Bool.Base using (Bool; T; not; if_then_else_)
 open import Data.Char.Base using (Char)
-open import Data.Product using (proj₁)
-open import Level.Bounded as Level≤ using (Set≤; theSet; [_]; lift; lower)
-open import Relation.Unary
+open import Data.Empty using (⊥)
+open import Data.Integer.Base using (ℤ)
+open import Data.Float.Base using (Float)
+open import Data.List.Base as List using (List; []; null)
+open import Data.List.NonEmpty as List⁺ using (List⁺)
+open import Data.Maybe.Base using (Maybe)
+open import Data.Nat.Base using (ℕ; _≡ᵇ_; NonZero)
+import Data.Nat.Properties as ℕₚ
+open import Data.Product using (_×_; _,_; proj₁)
+open import Data.Sign.Base using (Sign)
+open import Data.String.Base as String using (String)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
+open import Data.Unit.Base using (⊤)
+open import Data.Vec.Base using (Vec)
+open import Relation.Binary.PropositionalEquality using (refl)
+open import Relation.Binary.PropositionalEquality.Decidable
 
-open import Text.Parser.Types.Core
-open import Text.Parser.Monad
-open import Text.Parser.Position as Position using (Position; module Position) public
+open import Data.Singleton as Singleton public using (_!)
+open import Induction.Nat.Strong public using (□_; call)
+open import Relation.Unary public using (IUniversal; _⇒_)
 
-module CHARS = Agdarsec l [ Position ] Level≤.⊥ (record { into = proj₁ })
 
--- Our sized text is represented using vectors of characters
+open import Text.Parser.Types.Core using (module Success)
+import Text.Parser.Types {0ℓ} as Types
+import Text.Parser.Monad as Monad
+import Text.Parser.Monad.Result as Result
+
+open import Text.Parser.Position as Position public hiding (show)
+open import Data.List.Sized.Interface using (Sized)
+open import Data.Subset
+open import Data.Text.Sized renaming (text to sized-text)
 
 private
-  ParserM : Set l → Set l
-  ParserM = AgdarsecT [ Position ] Level≤.⊥ Identity
+  module TXT = Monad.Agdarsec 0ℓ [ Position ] Level≤.⊥ (record { into = proj₁ })
+  P = Monad.AgdarsecT.raw {0ℓ} [ Position ] Level≤.⊥ Identity.monad (record { into = proj₁ })
+  ParserM = Monad.AgdarsecT {0ℓ} [ Position ] Level≤.⊥ Identity
 
-  P : Parameters l
-  P = CHARS.chars
-
--- We re-export all of the combinators someone may need, specialised to CHARS
-
-open Level≤ using ([_]) public
-open import Text.Parser.Types               P hiding (runParser) public
-open import Text.Parser.Combinators         {P = P} public
-open import Text.Parser.Combinators.Numbers {P = P} public
-open import Text.Parser.Combinators.Char    {P = P} public
-
--- We export all of the instances that are needed for the combinators to work
--- out of the box
-
-open import Data.List.Sized.Interface using (vec) public
-open import Data.Subset using (Subset-refl) public
-open import Relation.Binary.PropositionalEquality.Decidable using (decide-char) public
-
-instance
+private instance
 
   P-monad : RawMonad ParserM
-  P-monad  = CHARS.monad
+  P-monad  = TXT.monad
 
   P-monad0 : RawMonadZero ParserM
-  P-monad0 = CHARS.monadZero
+  P-monad0 = TXT.monadZero
 
   P-monad+ : RawMonadPlus ParserM
-  P-monad+ = CHARS.monadPlus
+  P-monad+ = TXT.monadPlus
 
--- Finally we define a function to run a parser and readily obtain a value
+  P-sized : Sized {0ℓ} [ Char ] (λ n → [ Text n ])
+  P-sized = sized-text
 
-open import Data.Bool.Base using (if_then_else_)
-open import Data.List.Base using ([])
-open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
-open import Data.Nat.Base using (_≡ᵇ_)
-import Data.Nat.Properties as ℕₚ
-open import Data.Product using (_,_)
-open import Data.String as String using (String)
-open import Function.Base using (case_of_)
+Parser : (A : Set) (n : ℕ) → Set
+Parser A = Types.Parser P [ A ]
 
-import Text.Parser.Monad.Result as Result
-open import Text.Parser.Position using (start)
+private
+  variable
+    A B C : Set
 
-runParser : {A : Set≤ l} → ∀[ Parser A ] → String → Position ⊎ theSet A
+runParser : ∀[ Parser A ] → String → Position ⊎ A
 runParser p str =
-  let init  = lift (start , [])
-      input = lift (String.toVec str)
-  in case Result.toSum (Parser.runParser p (ℕₚ.n≤1+n _) input init) of λ where
-        (inj₂ (res , p)) → let open Success in
-                           if size res ≡ᵇ 0
-                           then inj₂ (lower (value res))
-                           else inj₁ (proj₁ (lower p))
-        (inj₁ p) → inj₁ (lower p)
+  let init  = Level≤.lift (start , [])
+      input = Level≤.lift (mkText str refl)
+  in case Result.toSum (Types.Parser.runParser p (ℕₚ.n≤1+n _) input init) of λ where
+        (inj₂ (res , p)) → if Success.size res ≡ᵇ 0
+                           then inj₂ (Level≤.lower (Success.value res))
+                           else inj₁ (proj₁ (Level≤.lower p))
+        (inj₁ p) → inj₁ (Level≤.lower p)
 
-open import IO
+_∈_ : String → ∀[ Parser A ] → Set
+str ∈ p = Singleton.fromInj₂ (runParser p str)
+
+_∉_ : String → ∀[ Parser A ] → Set
+str ∉ p = [ const ⊤ , const ⊥ ]′ (runParser p str)
+
+open import IO using (IO; pure)
 open import System.Exit
 
-runParserIO : {A : Set≤ l} → ∀[ Parser A ] → String → IO (theSet A)
+runParserIO : ∀[ Parser A ] → String → IO A
 runParserIO p str = case runParser p str of λ where
   (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
   (inj₂ val) → pure val
+
+import Text.Parser.Combinators {0ℓ} {P} as Combinators
+
+anyTok : ∀[ Parser Char ]
+anyTok = Combinators.anyTok
+
+anyChar = anyTok
+
+guardM : (A → Maybe B) → ∀[ Parser A ⇒ Parser B ]
+guardM = Combinators.guardM
+
+guard : (A → Bool) → ∀[ Parser A ⇒ Parser A ]
+guard = Combinators.guard
+
+maybeTok : (Char → Maybe A) → ∀[ Parser A ]
+maybeTok = Combinators.maybeTok
+
+maybeChar = maybeTok
+
+box : ∀[ Parser A ⇒ □ Parser A ]
+box = Combinators.box
+
+fail : ∀[ Parser A ]
+fail = Combinators.fail
+
+infixr 3 _<|>_
+_<|>_ : ∀[ Parser A ⇒ Parser A ⇒ Parser A ]
+_<|>_ = Combinators._<|>_
+
+lift2 : ∀[ Parser A ⇒ Parser B ⇒ Parser C ] →
+        ∀[ □ (Parser A) ⇒ □ (Parser B) ⇒ □ (Parser C) ]
+lift2 = Combinators.lift2
+
+lift2l : ∀[ Parser A ⇒ Parser B ⇒ Parser C ] ->
+         ∀[ □ (Parser A) ⇒ Parser B ⇒ □ (Parser C) ]
+lift2l = Combinators.lift2l
+
+lift2r : ∀[ Parser A ⇒ Parser B ⇒ Parser C ] ->
+         ∀[ Parser A ⇒ □ (Parser B) ⇒ □ (Parser C) ]
+lift2r = Combinators.lift2r
+
+infixr 5 _<$>_
+_<$>_ : (A → B) → ∀[ Parser A ⇒ Parser B ]
+_<$>_ = Combinators._<$>_
+
+infixr 5 _<$_
+_<$_ : B → ∀[ Parser A ⇒ Parser B ]
+_<$_ = Combinators._<$_
+
+_&?>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒
+             Parser (A × Maybe B) ]
+_&?>>=_ = Combinators._&?>>=_
+
+_&>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒ Parser (A × B) ]
+_&>>=_ = Combinators._&>>=_
+
+_?&>>=_ : ∀[ Parser A ⇒ (const (Maybe A) ⇒ Parser B) ⇒
+            Parser (Maybe A × B) ]
+_?&>>=_ = Combinators._?&>>=_
+
+_>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒ Parser B ]
+_>>=_ = Combinators._>>=_
+
+infixl 4 _<&>_ _<&_ _&>_
+_<&>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser (A × B) ]
+_<&>_ = Combinators._<&>_
+
+_<&_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser A ]
+_<&_ = Combinators._<&_
+
+_&>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser B ]
+_&>_ = Combinators._&>_
+
+alts : ∀[ List ∘′ Parser A ⇒ Parser A ]
+alts = Combinators.alts
+
+ands : ∀[ List⁺ ∘′ Parser A ⇒ Parser (List⁺ A) ]
+ands = Combinators.ands
+
+infixl 4 _<*>_
+_<*>_ : ∀[ Parser (A → B) ⇒ □ Parser A ⇒ Parser B ]
+_<*>_ = Combinators._<*>_
+
+infixl 4 _<&?>_ _<&?_ _&?>_
+_<&?>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser (A × Maybe B) ]
+_<&?>_ = Combinators._<&?>_
+
+_<&?_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser A ]
+_<&?_ = Combinators._<&?_
+
+_&?>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser (Maybe B) ]
+_&?>_ = Combinators._&?>_
+
+infixr 3 _<⊎>_
+_<⊎>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (A ⊎ B) ]
+_<⊎>_ = Combinators._<⊎>_
+
+infixl 4 _<?&>_ _<?&_ _?&>_
+_<?&>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (Maybe A × B) ]
+_<?&>_ = Combinators._<?&>_
+
+_<?&_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (Maybe A) ]
+_<?&_ = Combinators._<?&_
+
+_?&>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser B ]
+_?&>_ = Combinators._?&>_
+
+between : ∀[ Parser A ⇒ □ Parser C ⇒ □ Parser B ⇒ Parser B ]
+between = Combinators.between
+
+between? : ∀[ Parser A ⇒ □ Parser C ⇒ Parser B ⇒ Parser B ]
+between? = Combinators.between?
+
+anyOf : List Char → ∀[ Parser Char ]
+anyOf = Combinators.anyOf
+
+exact : Char → ∀[ Parser Char ]
+exact = Combinators.exact
+
+exacts : List⁺ Char → ∀[ Parser (List⁺ Char) ]
+exacts = Combinators.exacts
+
+noneOf : List Char → ∀[ Parser Char ]
+noneOf = Combinators.noneOf
+
+anyTokenBut : Char → ∀[ Parser Char ]
+anyTokenBut = Combinators.anyTokenBut
+
+anyCharBut = anyTokenBut
+
+iterate : ∀[ Parser A ⇒ □ Parser (A → A) ⇒ Parser A ]
+iterate = Combinators.iterate
+
+hchainl : ∀[ Parser A ⇒ □ Parser (A → B → A) ⇒ □ Parser B ⇒ Parser A ]
+hchainl = Combinators.hchainl
+
+chainl1 : ∀[ Parser A ⇒ □ Parser (A → A → A) ⇒ Parser A ]
+chainl1 = Combinators.chainl1
+
+chainr1 : ∀[ Parser A ⇒ □ Parser (A → A → A) ⇒ Parser A ]
+chainr1 = Combinators.chainr1
+
+head+tail : ∀[ Parser A ⇒ □ Parser A ⇒ Parser (List⁺ A) ]
+head+tail = Combinators.head+tail
+
+list⁺ : ∀[ Parser A ⇒ Parser (List⁺ A) ]
+list⁺ = Combinators.list⁺
+
+replicate : (n : ℕ) → {NonZero n} → ∀[ Parser A ⇒ Parser (Vec A n) ]
+replicate = Combinators.replicate
+
+import Text.Parser.Combinators.Numbers {0ℓ} {P} as Numbers
+
+decimalDigit : ∀[ Parser ℕ ]
+decimalDigit = Numbers.decimalDigit
+
+hexadecimalDigit : ∀[ Parser ℕ ]
+hexadecimalDigit = Numbers.hexadecimalDigit
+
+sign : ∀[ Parser Sign ]
+sign = Numbers.sign
+
+decimalℕ : ∀[ Parser ℕ ]
+decimalℕ = Numbers.decimalℕ
+
+decimalℤ : ∀[ Parser ℤ ]
+decimalℤ = Numbers.decimalℤ
+
+decimalFloat : ∀[ Parser Float ]
+decimalFloat = Numbers.decimalFloat
+
+import Text.Parser.Combinators.Char {0ℓ} {P} as Chars
+
+char : Char → ∀[ Parser Char ]
+char = Chars.char
+
+noneOfChars : List Char → ∀[ Parser Char ]
+noneOfChars = Chars.noneOfChars
+
+anyOfChars : List Char → ∀[ Parser Char ]
+anyOfChars = Chars.anyOfChars
+
+space : ∀[ Parser Char ]
+space = Chars.space
+
+spaces : ∀[ Parser (List⁺ Char) ]
+spaces = Chars.spaces
+
+text : (t : String) {_ : T (not (null (String.toList t)))} →
+       ∀[ Parser (List⁺ Char) ]
+text = Chars.text
+
+parens : ∀[ □ Parser A ⇒ Parser A ]
+parens = Chars.parens
+
+parens? : ∀[ Parser A ⇒ Parser A ]
+parens? = Chars.parens?
+
+withSpaces : ∀[ Parser A ⇒ Parser A ]
+withSpaces = Chars.withSpaces
+
+lowerAlpha : ∀[ Parser Char ]
+lowerAlpha = Chars.lowerAlpha
+
+upperAlpha : ∀[ Parser Char ]
+upperAlpha = Chars.upperAlpha
+
+alpha : ∀[ Parser Char ]
+alpha = Chars.alpha
+
+alphas⁺ : ∀[ Parser (List⁺ Char) ]
+alphas⁺ = Chars.alphas⁺
+
+num : ∀[ Parser ℕ ]
+num = decimalDigit
+
+alphanum : ∀[ Parser (Char ⊎ ℕ) ]
+alphanum = Chars.alphanum
+
+stringLiteral : ∀[ Parser String ]
+stringLiteral = Chars.stringLiteral

--- a/src/Text/Parser.agda
+++ b/src/Text/Parser.agda
@@ -10,8 +10,6 @@
 --
 ------------------------------------------------------------------------
 
-{-# OPTIONS --guardedness #-}
-
 module Text.Parser where
 
 open import Level using (0ℓ)
@@ -94,14 +92,6 @@ str ∈ p = Singleton.fromInj₂ (runParser p str)
 
 _∉_ : String → ∀[ Parser A ] → Set
 str ∉ p = [ const ⊤ , const ⊥ ]′ (runParser p str)
-
-open import IO using (IO; pure)
-open import System.Exit
-
-runParserIO : ∀[ Parser A ] → String → IO A
-runParserIO p str = case runParser p str of λ where
-  (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
-  (inj₂ val) → pure val
 
 import Text.Parser.Combinators {0ℓ} {P} as Combinators
 

--- a/src/Text/Parser/IO.agda
+++ b/src/Text/Parser/IO.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --guardedness #-}
+
+module Text.Parser.IO where
+
+open import Data.String.Base as String using (String)
+open import Data.Sum.Base using (inj₁; inj₂)
+open import IO using (IO; pure)
+open import Function.Base using (case_of_)
+open import System.Exit
+
+import Text.Parser.Position as Position
+open import Text.Parser public
+
+private
+  variable
+    A : Set
+
+runParserIO : ∀[ Parser A ] → String → IO A
+runParserIO p str = case runParser p str of λ where
+  (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
+  (inj₂ val) → pure val

--- a/src/Text/Parser/Polymorphic.agda
+++ b/src/Text/Parser/Polymorphic.agda
@@ -1,0 +1,86 @@
+{-# OPTIONS --guardedness #-}
+
+open import Level using (Level)
+
+module Text.Parser.Polymorphic (l : Level) where
+
+open import Function.Identity.Categorical using (Identity)
+open import Category.Monad
+open import Data.Char.Base using (Char)
+open import Data.Product using (proj₁)
+open import Level.Bounded as Level≤ using (Set≤; theSet; [_]; lift; lower)
+open import Relation.Unary
+
+open import Text.Parser.Types.Core
+open import Text.Parser.Monad
+open import Text.Parser.Position as Position using (Position; module Position) public
+
+module CHARS = Agdarsec l [ Position ] Level≤.⊥ (record { into = proj₁ })
+
+-- Our sized text is represented using vectors of characters
+
+private
+  ParserM : Set l → Set l
+  ParserM = AgdarsecT [ Position ] Level≤.⊥ Identity
+
+  P : Parameters l
+  P = CHARS.chars
+
+-- We re-export all of the combinators someone may need, specialised to CHARS
+
+open Level≤ using ([_]) public
+open import Text.Parser.Types               P hiding (runParser) public
+open import Text.Parser.Combinators         {P = P} public
+open import Text.Parser.Combinators.Numbers {P = P} public
+open import Text.Parser.Combinators.Char    {P = P} public
+
+-- We export all of the instances that are needed for the combinators to work
+-- out of the box
+
+open import Data.List.Sized.Interface using (vec) public
+open import Data.Subset using (Subset-refl) public
+open import Relation.Binary.PropositionalEquality.Decidable using (decide-char) public
+
+instance
+
+  P-monad : RawMonad ParserM
+  P-monad  = CHARS.monad
+
+  P-monad0 : RawMonadZero ParserM
+  P-monad0 = CHARS.monadZero
+
+  P-monad+ : RawMonadPlus ParserM
+  P-monad+ = CHARS.monadPlus
+
+-- Finally we define a function to run a parser and readily obtain a value
+
+open import Data.Bool.Base using (if_then_else_)
+open import Data.List.Base using ([])
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+open import Data.Nat.Base using (_≡ᵇ_)
+import Data.Nat.Properties as ℕₚ
+open import Data.Product using (_,_)
+open import Data.String as String using (String)
+open import Function.Base using (case_of_)
+
+import Text.Parser.Monad.Result as Result
+open import Text.Parser.Position using (start)
+
+runParser : {A : Set≤ l} → ∀[ Parser A ] → String → Position ⊎ theSet A
+runParser p str =
+  let init  = lift (start , [])
+      input = lift (String.toVec str)
+  in case Result.toSum (Parser.runParser p (ℕₚ.n≤1+n _) input init) of λ where
+        (inj₂ (res , p)) → let open Success in
+                           if size res ≡ᵇ 0
+                           then inj₂ (lower (value res))
+                           else inj₁ (proj₁ (lower p))
+        (inj₁ p) → inj₁ (lower p)
+
+open import IO
+open import System.Exit
+
+runParserIO : {A : Set≤ l} → ∀[ Parser A ] → String → IO (theSet A)
+runParserIO p str = case runParser p str of λ where
+  (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
+  (inj₂ val) → pure val

--- a/src/Text/Parser/Polymorphic.agda
+++ b/src/Text/Parser/Polymorphic.agda
@@ -1,5 +1,3 @@
-{-# OPTIONS --guardedness #-}
-
 open import Level using (Level)
 
 module Text.Parser.Polymorphic (l : Level) where
@@ -9,7 +7,7 @@ open import Category.Monad
 open import Data.Char.Base using (Char)
 open import Data.Product using (proj₁)
 open import Level.Bounded as Level≤ using (Set≤; theSet; [_]; lift; lower)
-open import Relation.Unary
+open import Relation.Unary using (IUniversal; _⇒_) public
 
 open import Text.Parser.Types.Core
 open import Text.Parser.Monad
@@ -76,11 +74,3 @@ runParser p str =
                            then inj₂ (lower (value res))
                            else inj₁ (proj₁ (lower p))
         (inj₁ p) → inj₁ (lower p)
-
-open import IO
-open import System.Exit
-
-runParserIO : {A : Set≤ l} → ∀[ Parser A ] → String → IO (theSet A)
-runParserIO p str = case runParser p str of λ where
-  (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
-  (inj₂ val) → pure val

--- a/src/Text/Parser/Polymorphic/IO.agda
+++ b/src/Text/Parser/Polymorphic/IO.agda
@@ -1,0 +1,20 @@
+{-# OPTIONS --guardedness #-}
+
+open import Level using (Level)
+
+module Text.Parser.Polymorphic.IO (l : Level) where
+
+open import Level.Bounded using (Set≤; theSet)
+open import Data.String.Base as String using (String)
+open import Data.Sum.Base using (inj₁; inj₂)
+open import IO using (IO; pure)
+open import Function.Base using (case_of_)
+open import System.Exit
+
+import Text.Parser.Position as Position
+open import Text.Parser.Polymorphic l public
+
+runParserIO : {A : Set≤ l} → ∀[ Parser A ] → String → IO (theSet A)
+runParserIO p str = case runParser p str of λ where
+  (inj₁ pos) → die ("Parse error at position: " String.++ Position.show pos)
+  (inj₂ val) → pure val


### PR DESCRIPTION
An opinionated frontend for the parser combinator library.
The `Text.Parser` module re-exports specialised versions of the combinators.
The design choices are as follows:

* Everything at level 0 (see `Text.Parser.Polymorphic` otherwise)
* `Char` as the type of tokens
* Sized `Text` as the type of token lists
* `Position` as the error annotation