### PR TITLE
[ new ] dependend bind combinators

### DIFF
--- a/examples/Matrix.agda
+++ b/examples/Matrix.agda
@@ -1,0 +1,55 @@
+module Matrix where
+
+open import Data.Maybe.Base as Maybe
+open import Data.Nat.Base
+open import Data.Product as Product
+open import Data.Sum.Base
+open import Data.Vec.Base as Vec using (Vec; _∷_; [])
+open import Function.Base
+open import Relation.Nullary
+
+open import Text.Parser
+
+Matrix : Set → ℕ → ℕ → Set
+Matrix a m n = Vec (Vec a n) m
+
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+
+indices : ∀[ Parser ((Σ[ m ∈ ℕ ] Σ[ n ∈ ℕ ] (m ≡ 0 ⊎ n ≡ 0))
+                   ⊎ (Σ[ m ∈ ℕ ] Σ[ n ∈ ℕ ] (NonZero m × NonZero n))) ]
+indices = f <$> (decimalℕ <& box space <&> box decimalℕ) where
+
+  f : ℕ × ℕ → (Σ[ m ∈ ℕ ] Σ[ n ∈ ℕ ] (m ≡ 0 ⊎ n ≡ 0))
+            ⊎ (Σ[ m ∈ ℕ ] Σ[ n ∈ ℕ ] (NonZero m × NonZero n))
+  f (zero , n) = inj₁ (zero , n , inj₁ refl)
+  f (m , zero) = inj₁ (m , zero , inj₂ refl)
+  f (suc m , suc n) = inj₂ (suc m , suc n , _)
+
+matrix : ∀[ Parser (Σ ℕ λ m → Σ ℕ λ n → Matrix ℕ m n) ]
+matrix = <[ ((λ (m , n , p) → [ (λ _ → 0 , n , []) , (λ _ → m , 0 , Vec.replicate []) ] p))
+          , (λ (m , n , p , q) → box $ (m ,_) ∘ (n ,_) <$> replicate m {{p}} (replicate n {{q}} (space &> box decimalℕ)))
+          ]> indices
+
+_ : "2 2 1 2 3 4" ∈ matrix
+_ = 2 , 2
+  , (1 ∷ 2 ∷ [])
+  ∷ (3 ∷ 4 ∷ [])
+  ∷ [] !
+
+_ : "1 3 1 2 3" ∈ matrix
+_ = 1 , 3
+  , (1 ∷ 2 ∷ 3 ∷ [])
+  ∷ [] !
+
+_ : "3 1 1 2 3" ∈ matrix
+_ = 3 , 1
+  , (1 ∷ [])
+  ∷ (2 ∷ [])
+  ∷ (3 ∷ [])
+  ∷ [] !
+
+_ : "0 3" ∈ matrix
+_ = 0 , 3 , [] !
+
+_ : "3 0" ∈ matrix
+_ = 3 , 0 , [] ∷ [] ∷ [] ∷ [] !

--- a/examples/Matrix.agda
+++ b/examples/Matrix.agda
@@ -25,7 +25,7 @@ indices = f <$> (decimalℕ <& box space <&> box decimalℕ) where
   f (m , zero) = inj₁ (m , zero , inj₂ refl)
   f (suc m , suc n) = inj₂ (suc m , suc n , _)
 
-matrix : ∀[ Parser (Σ ℕ λ m → Σ ℕ λ n → Matrix ℕ m n) ]
+matrix : ∀[ Parser (Σ[ m ∈ ℕ ] Σ[ n ∈ ℕ ] Matrix ℕ m n) ]
 matrix = <[ ((λ (m , n , p) → [ (λ _ → 0 , n , []) , (λ _ → m , 0 , Vec.replicate []) ] p))
           , (λ (m , n , p , q) → box $ (m ,_) ∘ (n ,_) <$> replicate m {{p}} (replicate n {{q}} (space &> box decimalℕ)))
           ]> indices

--- a/examples/Vec.agda
+++ b/examples/Vec.agda
@@ -12,14 +12,23 @@ n-times p = decimalℕ &>>= λ n → box (replicate (suc n) p)
 n-times? : {A : Set} → ∀[ Parser A ⇒ Parser (∃[ n ] Maybe (Vec A (suc n))) ]
 n-times? p = decimalℕ &?>>= λ n → box (replicate (suc n) p)
 
-_ : "0 0" ∈ n-times (space &> box decimalℕ)
+space-ℕ : ∀[ Parser ℕ ]
+space-ℕ = space &> box decimalℕ
+
+_ : "0 0" ∈ n-times space-ℕ
 _ = 0 , 0 ∷ [] !
 
-_ : "1 0 1" ∈ n-times (space &> box decimalℕ)
+_ : "1 0 1" ∈ n-times space-ℕ
 _ = 1 , 0 ∷ 1 ∷ [] !
 
-_ : "1 0 1" ∈ n-times? (space &> box decimalℕ)
+_ : "1 0 1" ∈ n-times? space-ℕ
 _ = 1 , just (0 ∷ 1 ∷ []) !
 
-_ : "1" ∈ n-times? (space &> box decimalℕ)
+_ : "1" ∈ n-times? space-ℕ
+_ = 1 , nothing !
+
+_ : "1 1" ∉ n-times? space-ℕ
+_ = _
+
+_ : "1 1" ∈ (n-times? space-ℕ <& box space-ℕ)
 _ = 1 , nothing !

--- a/examples/Vec.agda
+++ b/examples/Vec.agda
@@ -1,6 +1,7 @@
 module Vec where
 
 open import Text.Parser
+open import Data.Unit.Base
 open import Data.Vec hiding (replicate)
 open import Data.Maybe
 open import Data.Nat

--- a/examples/Vec.agda
+++ b/examples/Vec.agda
@@ -1,0 +1,25 @@
+module Vec where
+
+open import Text.Parser
+open import Data.Vec hiding (replicate)
+open import Data.Maybe
+open import Data.Nat
+open import Data.Product
+
+n-times : {A : Set} → ∀[ Parser A ⇒ Parser (∃[ n ] Vec A (suc n)) ]
+n-times p = decimalℕ &>>= λ n → box (replicate (suc n) p)
+
+n-times? : {A : Set} → ∀[ Parser A ⇒ Parser (∃[ n ] Maybe (Vec A (suc n))) ]
+n-times? p = decimalℕ &?>>= λ n → box (replicate (suc n) p)
+
+_ : "0 0" ∈ n-times (space &> box decimalℕ)
+_ = 0 , 0 ∷ [] !
+
+_ : "1 0 1" ∈ n-times (space &> box decimalℕ)
+_ = 1 , 0 ∷ 1 ∷ [] !
+
+_ : "1 0 1" ∈ n-times? (space &> box decimalℕ)
+_ = 1 , just (0 ∷ 1 ∷ []) !
+
+_ : "1" ∈ n-times? (space &> box decimalℕ)
+_ = 1 , nothing !

--- a/examples/examples.agda-lib
+++ b/examples/examples.agda-lib
@@ -1,0 +1,3 @@
+name: agdarsec-examples
+include: .
+depend: standard-library, agdarsec

--- a/index.agda
+++ b/index.agda
@@ -40,6 +40,7 @@ import RegExp
 import NList
 import SExp
 import Vec
+import Matrix
 
 -- And even a parser returning a large type
 

--- a/index.agda
+++ b/index.agda
@@ -39,6 +39,7 @@ import Parentheses
 import RegExp
 import NList
 import SExp
+import Vec
 
 -- And even a parser returning a large type
 

--- a/src/Level/Bounded.agda
+++ b/src/Level/Bounded.agda
@@ -39,6 +39,10 @@ record Set≤ (l : Level) : Setω where
         theSet : Set (level level≤)
 open Set≤ public
 
+mkSet≤ : {l b : Level} → {{b ≤l l}} → Set b → Set≤ l
+mkSet≤ {{pr}} A .level≤ = MkLevel≤ _
+mkSet≤        A .theSet = A
+
 ------------------------------------------------------------------------
 -- Type constructors
 

--- a/src/Text/Parser.agda
+++ b/src/Text/Parser.agda
@@ -27,7 +27,7 @@ open import Data.List.NonEmpty as List⁺ using (List⁺)
 open import Data.Maybe.Base using (Maybe)
 open import Data.Nat.Base using (ℕ; _≡ᵇ_; NonZero)
 import Data.Nat.Properties as ℕₚ
-open import Data.Product using (_×_; _,_; proj₁)
+open import Data.Product using (Σ; Σ-syntax; _×_; _,_; proj₁)
 open import Data.Sign.Base using (Sign)
 open import Data.String.Base as String using (String)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
@@ -141,16 +141,30 @@ infixr 5 _<$_
 _<$_ : B → ∀[ Parser A ⇒ Parser B ]
 _<$_ = Combinators._<$_
 
-_&?>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒
-             Parser (A × Maybe B) ]
+_&?>>=_ : {B : A → Set} →
+          ∀ {n} → Parser A n → ((a : A) → (□ Parser (B a)) n) →
+          Parser (Σ[ a ∈ A ] Maybe (B a)) n
 _&?>>=_ = Combinators._&?>>=_
 
-_&>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒ Parser (A × B) ]
+_&>>=_ : {B : A → Set} →
+         ∀ {n} → Parser A n → ((a : A) → (□ Parser (B a)) n) → Parser (Σ A B) n
 _&>>=_ = Combinators._&>>=_
 
-_?&>>=_ : ∀[ Parser A ⇒ (const (Maybe A) ⇒ Parser B) ⇒
-            Parser (Maybe A × B) ]
+_?&>>=_ : {B : Maybe A → Set} →
+          ∀ {n} → Parser A n → ((ma : Maybe A) → Parser (B ma) n) →
+          Parser (Σ[ ma ∈ Maybe A ] B ma) n
 _?&>>=_ = Combinators._?&>>=_
+
+_&?>>=′_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒
+             Parser (A × Maybe B) ]
+_&?>>=′_ = Combinators._&?>>=′_
+
+_&>>=′_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒ Parser (A × B) ]
+_&>>=′_ = Combinators._&>>=′_
+
+_?&>>=′_ : ∀[ Parser A ⇒ (const (Maybe A) ⇒ Parser B) ⇒
+              Parser (Maybe A × B) ]
+_?&>>=′_ = Combinators._?&>>=′_
 
 _>>=_ : ∀[ Parser A ⇒ (const A ⇒ □ Parser B) ⇒ Parser B ]
 _>>=_ = Combinators._>>=_

--- a/src/Text/Parser.agda
+++ b/src/Text/Parser.agda
@@ -75,7 +75,7 @@ Parser A = Types.Parser P [ A ]
 
 private
   variable
-    A B C : Set
+    A B C R : Set
 
 runParser : ∀[ Parser A ] → String → Position ⊎ A
 runParser p str =
@@ -203,6 +203,9 @@ infixr 3 _<⊎>_
 _<⊎>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (A ⊎ B) ]
 _<⊎>_ = Combinators._<⊎>_
 
+<[_,_]> : ∀[ const (A → R) ⇒ (const B ⇒ □ Parser R) ⇒ Parser (A ⊎ B) ⇒ Parser R ]
+<[_,_]> = Combinators.<[_,_]>
+
 infixl 4 _<?&>_ _<?&_ _?&>_
 _<?&>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (Maybe A × B) ]
 _<?&>_ = Combinators._<?&>_
@@ -254,7 +257,7 @@ head+tail = Combinators.head+tail
 list⁺ : ∀[ Parser A ⇒ Parser (List⁺ A) ]
 list⁺ = Combinators.list⁺
 
-replicate : (n : ℕ) → {NonZero n} → ∀[ Parser A ⇒ Parser (Vec A n) ]
+replicate : (n : ℕ) → {{NonZero n}} → ∀[ Parser A ⇒ Parser (Vec A n) ]
 replicate = Combinators.replicate
 
 import Text.Parser.Combinators.Numbers {0ℓ} {P} as Numbers

--- a/src/Text/Parser/Combinators.agda
+++ b/src/Text/Parser/Combinators.agda
@@ -13,9 +13,9 @@ open import Data.Nat.Base using (ℕ; _≤_; _<_)
 open import Data.Bool.Base as Bool using (Bool; if_then_else_; not; _∧_)
 open import Data.List.Base as List using (_∷_; []; null)
 open import Data.List.NonEmpty as List⁺ using (_∷⁺_ ; _∷_)
-open import Data.Maybe.Base using (just; nothing; maybe)
+open import Data.Maybe.Base as M using (just; nothing; maybe)
 open import Data.Nat.Base using (suc; NonZero)
-open import Data.Product as Product using (_,_; proj₁; proj₂; uncurry)
+open import Data.Product as Product using (Σ-syntax; _,_; proj₁; proj₂; uncurry)
 open import Data.Sum.Base as Sum using (inj₁; inj₂)
 open import Data.Vec.Base as Vec using (_∷_; [])
 
@@ -90,26 +90,18 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
            ∀[ Parser A ⇒ □ (Parser B) ⇒ □ (Parser C) ]
   lift2r f a b = lift2 f (box a) b
 
- module _ {A B : Set≤ l} where
+ module _ {A : Set≤ l} {b} {{b≤l : b ≤l l}} {B : theSet A → Set b} where
 
-  infixr 5 _<$>_
-  _<$>_ : theSet (A ⟶ B) → ∀[ Parser A ⇒ Parser B ]
-  runParser (f <$> p) lt s = S.map f 𝕄.<$> (runParser p lt s)
-
-  infixr 5 _<$_
-  _<$_ : theSet B → ∀[ Parser A ⇒ Parser B ]
-  b <$ p = const b <$> p
-
-  _&?>>=_ : ∀[ Parser A ⇒ (const (theSet A) ⇒ □ Parser B) ⇒
-               Parser (A × Maybe B) ]
+  _&?>>=_ : ∀ {n} → Parser A n → ((a : theSet A) → (□ Parser (mkSet≤ (B a))) n) →
+            Parser (Σ A λ a → M.Maybe (B a)) n
   runParser (A &?>>= B) m≤n s =
     runParser A m≤n s 𝕄.>>= λ rA →
     let (a ^ p<m , s′) = rA in
-    (runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
-     𝕄.return (S.and rA (S.map just rB)))
-    𝕄.∣ 𝕄.return (lift (lower a , nothing) ^ p<m , s′)
+    runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
+    𝕄.return (S.and rA (S.map just rB)) 𝕄.∣ 𝕄.return ((lift (lower a , nothing)) ^ p<m , s′)
 
-  _&>>=_ : ∀[ Parser A ⇒ (const (theSet A) ⇒ □ Parser B) ⇒ Parser (A × B) ]
+  _&>>=_ : ∀ {n} → Parser A n → ((a : theSet A) → (□ Parser (mkSet≤ (B a))) n) →
+           Parser (Σ A B) n
   runParser (A &>>= B) m≤n s =
     runParser A m≤n s 𝕄.>>= λ rA →
     let (a ^ p<m , s′) = rA in
@@ -118,19 +110,58 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
 
  module _ {A B : Set≤ l} where
 
-  _?&>>=_ : ∀[ Parser A ⇒ (const (theSet (Maybe A)) ⇒ Parser B) ⇒
-            Parser (Maybe A × B) ]
-  A ?&>>= B = (Product.map₁ just <$> A &>>= λ a → box (B (just a)))
-          <|> ((nothing ,_)   <$> B nothing)
+  infixr 5 _<$>_
+  _<$>_ : theSet (A ⟶ B) → ∀[ Parser A ⇒ Parser B ]
+  runParser (f <$> p) lt s = S.map f 𝕄.<$> runParser p lt s
+
+  infixr 5 _<$_
+  _<$_ : theSet B → ∀[ Parser A ⇒ Parser B ]
+  b <$ p = const b <$> p
+
+ module _ {A : Set≤ l} {b} {{b≤l : b ≤l l}} {B : theSet (Maybe A) → Set b} where
+
+  _?&>>=_ : ∀ {n} → Parser A n → ((ma : theSet (Maybe A)) → Parser (mkSet≤ (B ma)) n) →
+            Parser (Σ (Maybe A) B) n
+  runParser (_?&>>=_ {n} pA pB) m≤n s =
+   let p : Parser (A ⊎ mkSet≤ (B nothing)) n
+       p = inj₁ <$> pA <|> inj₂ <$> pB nothing
+   in runParser p m≤n s 𝕄.>>= λ (v ^ p<m , ts) → case lower v of λ where
+        (inj₂ b) → 𝕄.pure (lift (nothing , b) ^ p<m , ts)
+        (inj₁ a) → (S.map (just a ,_) ∘′ <-lift p<m)
+             𝕄.<$> runParser (pB (just a)) (≤-trans (<⇒≤ p<m) m≤n) ts
+
+ module _ {A B : Set≤ l} where
+
+  _&?>>=′_ : ∀[ Parser A ⇒ (const (theSet A) ⇒ □ Parser B) ⇒
+                Parser (A × Maybe B) ]
+  runParser (A &?>>=′ B) m≤n s =
+    runParser A m≤n s 𝕄.>>= λ rA →
+    let (a ^ p<m , s′) = rA in
+    (runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
+     𝕄.return (S.and′ rA (S.map just rB)))
+    𝕄.∣ 𝕄.return (lift (lower a , nothing) ^ p<m , s′)
+
+  _&>>=′_ : ∀[ Parser A ⇒ (const (theSet A) ⇒ □ Parser B) ⇒ Parser (A × B) ]
+  runParser (A &>>=′ B) m≤n s =
+    runParser A m≤n s 𝕄.>>= λ rA →
+    let (a ^ p<m , s′) = rA in
+    (runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
+     𝕄.return (S.and′ rA rB))
+
+ module _ {A B : Set≤ l} where
+
+  _?&>>=′_ : ∀[ Parser A ⇒ (const (theSet (Maybe A)) ⇒ Parser B) ⇒
+                Parser (Maybe A × B) ]
+  _?&>>=′_ = _?&>>=_
 
  module _ {A B : Set≤ l} where
 
   _>>=_ : ∀[ Parser A ⇒ (const (theSet A) ⇒ □ Parser B) ⇒ Parser B ]
-  A >>= B = proj₂ <$> A &>>= B
+  A >>= B = proj₂ <$> A &>>=′ B
 
   infixl 4 _<&>_ _<&_ _&>_
   _<&>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser (A × B) ]
-  A <&> B = A &>>= const B
+  A <&> B = A &>>=′ const B
 
   _<&_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser A ]
   A <& B = proj₁ <$> (A <&> B)
@@ -167,7 +198,7 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
 
   infixl 4 _<&?>_ _<&?_ _&?>_
   _<&?>_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser (A × Maybe B) ]
-  A <&?> B = A &?>>= const B
+  A <&?> B = A &?>>=′ const B
 
   _<&?_ : ∀[ Parser A ⇒ □ Parser B ⇒ Parser A ]
   A <&? B = proj₁ <$> (A <&?> B)

--- a/src/Text/Parser/Combinators.agda
+++ b/src/Text/Parser/Combinators.agda
@@ -211,6 +211,18 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
   _<⊎>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (A ⊎ B) ]
   A <⊎> B = inj₁ <$> A <|> inj₂ <$> B
 
+ module _ {A B R : Set≤ l} where
+
+  <[_,_]> : ∀[ const (theSet A → theSet R) ⇒ (const (theSet B) ⇒ □ Parser R) ⇒
+               Parser (A ⊎ B) ⇒ Parser R ]
+  runParser (<[ f , k ]> A⊎B) m≤n s =
+    runParser A⊎B m≤n s 𝕄.>>= λ rA⊎B → let (v ^ p<m , s′) = rA⊎B in
+    case lower v of λ where
+      (inj₁ a) → 𝕄.return (lift (f a) ^ p<m , s′)
+      (inj₂ b) → <-lift p<m 𝕄.<$> runParser (Box.call (k b) (≤-trans p<m m≤n)) ≤-refl s′
+
+ module _ {A B : Set≤ l} where
+
   infixl 4 _<?&>_ _<?&_ _?&>_
   _<?&>_ : ∀[ Parser A ⇒ Parser B ⇒ Parser (Maybe A × B) ]
   A <?&> B = just <$> A <&> box B <|> (nothing ,_) <$> B
@@ -310,6 +322,6 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
           uncurry (λ hd → (hd ∷_) ∘′ maybe List⁺.toList [])
           <$> (pA <&?> (Box.app rec (box pA)))
 
-  replicate : (n : ℕ) → {NonZero n} → ∀[ Parser A ⇒ Parser (Vec A n) ]
+  replicate : (n : ℕ) → {{NonZero n}} → ∀[ Parser A ⇒ Parser (Vec A n) ]
   replicate 1               p = Vec.[_] <$> p
   replicate (suc n@(suc _)) p = uncurry Vec._∷_ <$> (p <&> box (replicate n p))

--- a/src/Text/Parser/Combinators.agda
+++ b/src/Text/Parser/Combinators.agda
@@ -97,8 +97,9 @@ module _ {{𝕊 : Sized Tok Toks}} {{𝕄 : RawMonadPlus M}}
   runParser (A &?>>= B) m≤n s =
     runParser A m≤n s 𝕄.>>= λ rA →
     let (a ^ p<m , s′) = rA in
-    runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
-    𝕄.return (S.and rA (S.map just rB)) 𝕄.∣ 𝕄.return ((lift (lower a , nothing)) ^ p<m , s′)
+    (runParser (Box.call (B (lower a)) (≤-trans p<m m≤n)) ≤-refl s′ 𝕄.>>= λ rB →
+    𝕄.return (S.and rA (S.map just rB)))
+    𝕄.∣ 𝕄.return ((lift (lower a , nothing)) ^ p<m , s′)
 
   _&>>=_ : ∀ {n} → Parser A n → ((a : theSet A) → (□ Parser (mkSet≤ (B a))) n) →
            Parser (Σ A B) n

--- a/src/Text/Parser/Combinators/Char.agda
+++ b/src/Text/Parser/Combinators/Char.agda
@@ -4,6 +4,7 @@ open import Text.Parser.Types.Core using (Parameters)
 
 module Text.Parser.Combinators.Char {l} {P : Parameters l} where
 
+open import Data.Unit.Base
 open import Data.Bool.Base using (T; not)
 open import Data.Char.Base using (Char)
 open import Data.List.Base as List using ([]; _∷_; null)

--- a/src/Text/Parser/Success.agda
+++ b/src/Text/Parser/Success.agda
@@ -4,7 +4,7 @@ open import Text.Parser.Types.Core using (Parameters)
 
 module Text.Parser.Success {l} (P : Parameters l) where
 
-open import Level.Bounded as Level≤ using (Set≤; _×_; theSet; lift; lower)
+open import Level.Bounded as Level≤ using (_≤l_; Set≤; Σ; _×_; mkSet≤; theSet; lift; lower)
 open import Data.Nat.Base using (ℕ; zero; suc; _≤_; _<_)
 open import Data.Nat.Properties using (≤-trans; <⇒≤; ≤-refl)
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just)
@@ -35,11 +35,18 @@ module _ {A : Set≤ l} {m n : ℕ} where
   <-lift : .(le : m < n) → Success Toks A m → Success Toks A n
   <-lift m<n = ≤-lift (<⇒≤ m<n)
 
+module _ {A : Set≤ l} {b} {{b≤l : b ≤l l}} {B : theSet A → Set b} where
+
+  and : ∀ {n} (p : Success Toks A n) →
+        Success Toks (mkSet≤ (B (lower $ value p))) (size p) →
+        Success Toks (Σ A B) n
+  and (a ^ m<n , v) q = <-lift m<n (map (lower a ,_) q)
+
 module _ {A B : Set≤ l} where
 
-  and : ∀ {n} (p : Success Toks A n) → Success Toks B (size p) →
-        Success Toks (A × B) n
-  and (a ^ m<n , v) q = <-lift m<n (map (lower a ,_) q)
+  and′ : ∀ {n} (p : Success Toks A n) → Success Toks B (size p) →
+         Success Toks (A × B) n
+  and′ (a ^ m<n , v) q = <-lift m<n (map (lower a ,_) q)
 
 module _ {{𝕊 : Sized Tok Toks}} where
 


### PR DESCRIPTION
Note that the semantics of `_?&>>=_` has changed from (approximately)
```
(just <$> a &>>= b) <|> ((nothing ,_) <$> b nothing)
```
to
```
(just <$> a <|> nothing) &>>= b
```
which I think is closer to what you'd expect: if `b (just a)` fails, it seems strange to rollback to before `a`.